### PR TITLE
Feature: Request Rate Limiter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,7 @@
+import Config
+
+# Rate Limiter configuration
+config :ex_banking,
+  max_requests: 20,
+  rate_units: :seconds,
+  sweep_rate: 60

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -9,7 +9,9 @@ defmodule ExBanking.Application do
     # List all child processes to be supervised
     children = [
       {Registry, keys: :unique, name: ExBanking.AccountsRegistry},
-      {DynamicSupervisor, strategy: :one_for_one, name: ExBanking.AccountsSupervisor}
+      {DynamicSupervisor, strategy: :one_for_one, name: ExBanking.AccountsSupervisor},
+      # Start RateLimiter
+      ExBanking.RateLimiter
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/ex_banking.ex
+++ b/lib/ex_banking.ex
@@ -6,6 +6,7 @@ defmodule ExBanking do
   alias ExBanking.Accounts
   alias ExBanking.Accounts.User
   alias ExBanking.Utils
+  alias ExBanking.RateLimiter
 
   @doc """
   Creates new user in the system
@@ -44,25 +45,25 @@ defmodule ExBanking do
           | {:error, :wrong_arguments | :user_does_not_exist | :too_many_requests_to_user}
   def deposit(user, amount, currency)
       when is_binary(user) and is_binary(currency) and is_number(amount) and amount >= 0 do
-    case Accounts.get_user_account(user) do
-      {:ok, account} ->
-        currencies = Map.get(account, :currencies)
+    with {:ok, account} <- Accounts.get_user_account(user),
+         :ok <- RateLimiter.log_request(user) do
+      currencies = Map.get(account, :currencies)
 
-        balance = Map.get(currencies, currency, 0.0)
+      balance = Map.get(currencies, currency, 0.0)
 
-        new_balance =
-          (balance + Utils.format_amount(amount))
-          |> Utils.format_amount()
+      new_balance =
+        (balance + Utils.format_amount(amount))
+        |> Utils.format_amount()
 
-        # Add or update existing currency amount
-        currencies = Map.put(currencies, currency, new_balance)
+      # Add or update existing currency amount
+      currencies = Map.put(currencies, currency, new_balance)
 
-        # Update user account
-        account = %User{currencies: currencies}
-        Accounts.update_account(user, account)
+      # Update user account
+      account = %User{currencies: currencies}
+      Accounts.update_account(user, account)
 
-        {:ok, new_balance}
-
+      {:ok, new_balance}
+    else
       {:error, reason} ->
         {:error, reason}
     end
@@ -89,31 +90,28 @@ defmodule ExBanking do
              | :too_many_requests_to_user}
   def withdraw(user, amount, currency)
       when is_binary(user) and is_number(amount) and amount >= 0 and is_binary(currency) do
-    case Accounts.get_user_account(user) do
-      {:ok, account} ->
-        currencies = Map.get(account, :currencies)
+    with {:ok, account} <- Accounts.get_user_account(user),
+         :ok <- RateLimiter.log_request(user) do
+      currencies = Map.get(account, :currencies)
 
-        blanace = Map.get(currencies, currency, 0.0)
+      blanace = Map.get(currencies, currency, 0.0)
 
-        if(amount > blanace) do
-          {:error, :not_enough_money}
-        else
-          new_balance =
-            (blanace - Utils.format_amount(amount))
-            |> Utils.format_amount()
+      if(amount > blanace) do
+        {:error, :not_enough_money}
+      else
+        new_balance =
+          (blanace - Utils.format_amount(amount))
+          |> Utils.format_amount()
 
-          # Update existing currency amount
-          currencies = Map.put(currencies, currency, new_balance)
+        # Update existing currency amount
+        currencies = Map.put(currencies, currency, new_balance)
 
-          # Update user account
-          account = %User{currencies: currencies}
-          Accounts.update_account(user, account)
+        # Update user account
+        account = %User{currencies: currencies}
+        Accounts.update_account(user, account)
 
-          {:ok, new_balance}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+        {:ok, new_balance}
+      end
     end
   end
 
@@ -132,16 +130,13 @@ defmodule ExBanking do
           {:ok, balance :: number}
           | {:error, :wrong_arguments | :user_does_not_exist | :too_many_requests_to_user}
   def get_balance(user, currency) when is_binary(user) and is_binary(currency) do
-    case Accounts.get_user_account(user) do
-      {:ok, account} ->
-        balance =
-          Map.get(account, :currencies)
-          |> Map.get(currency, 0.00)
+    with {:ok, account} <- Accounts.get_user_account(user),
+         :ok <- RateLimiter.log_request(user) do
+      balance =
+        Map.get(account, :currencies)
+        |> Map.get(currency, 0.00)
 
-        {:ok, balance}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, balance}
     end
   end
 
@@ -176,8 +171,8 @@ defmodule ExBanking do
       when is_binary(from_user) and is_binary(to_user) and is_number(amount) and amount >= 0 and
              is_binary(currency) do
     with(
-      {:ok, _from_user_account} <- validate_from_user(from_user),
-      {:ok, _to_user_account} <- vallidate_to_user(to_user),
+      {:ok, _from_user_account} <- validate_user(from_user, :sender),
+      {:ok, _to_user_account} <- validate_user(to_user, :receiver),
       {:ok, from_user_balance} <- from_user_withdraw(from_user, amount, currency),
       {:ok, to_user_balance} <- to_user_deposit(to_user, amount, currency)
     ) do
@@ -187,23 +182,22 @@ defmodule ExBanking do
 
   def send(_, _, _, _), do: {:error, :wrong_arguments}
 
-  defp validate_from_user(user) do
-    case Accounts.get_user_account(user) do
-      {:ok, user} ->
-        {:ok, user}
+  defp validate_user(user, type) do
+    with {:ok, account} <- Accounts.get_user_account(user),
+         :ok <- RateLimiter.log_request(user) do
+      {:ok, account}
+    else
+      {:error, :too_many_requests_to_user} ->
+        reason =
+          if type == :sender,
+            do: :too_many_requests_to_sender,
+            else: :too_many_requests_to_receiver
+
+        {:error, reason}
 
       {:error, _reason} ->
-        {:error, :sender_does_not_exist}
-    end
-  end
-
-  defp vallidate_to_user(user) do
-    case Accounts.get_user_account(user) do
-      {:ok, user} ->
-        {:ok, user}
-
-      {:error, _reason} ->
-        {:error, :receiver_does_not_exist}
+        reason = if type == :sender, do: :sender_does_not_exist, else: :receiver_does_not_exist
+        {:error, reason}
     end
   end
 

--- a/lib/ex_banking/rate_limiter.ex
+++ b/lib/ex_banking/rate_limiter.ex
@@ -1,0 +1,50 @@
+defmodule ExBanking.RateLimiter do
+  @moduledoc """
+  Handles user requests with auto sweeping ability
+  """
+
+  use GenServer
+  require Logger
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def log_request(uid) do
+    GenServer.call(__MODULE__, {:log_request, uid})
+  end
+
+  @impl true
+  @spec init(any) :: {:ok, %{requests: %{}}}
+  def init(_) do
+    schedule_sweep()
+    {:ok, %{requests: %{}}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    Logger.debug("Sweeping requests")
+    schedule_sweep()
+    {:noreply, %{state | requests: %{}}}
+  end
+
+  @impl true
+  def handle_call({:log_request, uid}, _from, state) do
+    max_requests = Application.get_env(:ex_banking, :max_requests)
+
+    case state.requests[uid] do
+      count when is_nil(count) or count < max_requests ->
+        {:reply, :ok, put_in(state, [:requests, uid], (count || 0) + 1)}
+
+      count when count >= max_requests ->
+        {:reply, {:error, :too_many_requests_to_user}, state}
+    end
+  end
+
+  defp schedule_sweep do
+    sweep_after = Application.get_env(:ex_banking, :sweep_rate)
+    sweep_after = :timer.seconds(sweep_after)
+
+    Process.send_after(self(), :sweep, sweep_after)
+  end
+end


### PR DESCRIPTION
This PR mostly focuses on adding and applying request rate limiter to public functions. 

There's some performance issues with this approach. Since this feature is for rate limiting, all user requests must pass through this server. Since messages are processed in serial, this effectively limits our application to single-threaded performance, and creates a bottleneck on this single process.
