### PR TITLE
Feature: Request Rate Limiter with ETS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,5 @@ import Config
 config :ex_banking,
   max_requests: 20,
   rate_units: :seconds,
-  sweep_rate: 60
+  sweep_rate: 60,
+  ets_table: :rater_limiter_requests

--- a/lib/ex_banking/rate_limiter.ex
+++ b/lib/ex_banking/rate_limiter.ex
@@ -10,35 +10,44 @@ defmodule ExBanking.RateLimiter do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def log_request(uid) do
-    GenServer.call(__MODULE__, {:log_request, uid})
+  @spec log_request( user :: String.t()) :: :ok | {:error, :too_many_requests_to_user}
+  def log_request(user) do
+    ets_table = get_ets_table()
+    max_requests = Application.get_env(:ex_banking, :max_requests)
+
+    case :ets.update_counter(ets_table, user, {2, 1}, {user, 0}) do
+      count when count > max_requests -> {:error, :too_many_requests_to_user}
+      _count -> :ok
+    end
   end
 
   @impl true
-  @spec init(any) :: {:ok, %{requests: %{}}}
+  @spec init(any) :: {:ok, %{}}
   def init(_) do
+    ets_table = get_ets_table()
+
+    :ets.new(ets_table, [
+      :set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
     schedule_sweep()
-    {:ok, %{requests: %{}}}
+    {:ok, %{}}
   end
 
   @impl true
   def handle_info(:sweep, state) do
     Logger.debug("Sweeping requests")
+
+    ets_table = get_ets_table()
+    :ets.delete_all_objects(ets_table)
+
     schedule_sweep()
-    {:noreply, %{state | requests: %{}}}
-  end
 
-  @impl true
-  def handle_call({:log_request, uid}, _from, state) do
-    max_requests = Application.get_env(:ex_banking, :max_requests)
-
-    case state.requests[uid] do
-      count when is_nil(count) or count < max_requests ->
-        {:reply, :ok, put_in(state, [:requests, uid], (count || 0) + 1)}
-
-      count when count >= max_requests ->
-        {:reply, {:error, :too_many_requests_to_user}, state}
-    end
+    {:noreply, state}
   end
 
   defp schedule_sweep do
@@ -46,5 +55,9 @@ defmodule ExBanking.RateLimiter do
     sweep_after = :timer.seconds(sweep_after)
 
     Process.send_after(self(), :sweep, sweep_after)
+  end
+
+  defp get_ets_table do
+    Application.get_env(:ex_banking, :ets_table)
   end
 end


### PR DESCRIPTION
In the previous PR #2 description , We described that there's some performance issues with the previous rate limiter approach. So what's the solution to gain performance without any third-party library? Simply `ETS` can help us to  make concurrent request logger for clients at the moment.

We can refactor our rate limiter server to use a publicly accessible ETS table so clients can log their requests directly in ets, and our owning process can be responsible only for sweeping and cleaning up the table. This allows concurrent reads and writes against ETS without having to serialize calls through the single server.

Note:
```
read_concurrency and write_concurrency options set to true to optimize access
```
